### PR TITLE
[Fix] Add missing volumes definition to Farm calendar

### DIFF
--- a/available_services/farmcalendar.yml
+++ b/available_services/farmcalendar.yml
@@ -52,3 +52,6 @@ services:
         condition: service_healthy
       gatekeeper:
         condition: service_healthy
+
+volumes:
+  farmcalendar_db_data:


### PR DESCRIPTION
sorry guys, completely lapsed and left the actual volume definition for the farmcalendar db out of the file... now it's there :sweat: 